### PR TITLE
Sort primary keys in PathMappingCollection only when necessary.

### DIFF
--- a/src/Repository/Mapping/PathMappingCollection.php
+++ b/src/Repository/Mapping/PathMappingCollection.php
@@ -140,7 +140,10 @@ class PathMappingCollection
      */
     public function listByPackageName($packageName)
     {
-        $this->lazySortPrimaryKeys();
+        if ($this->primaryKeysSorted === true) {
+            $this->lazySortPrimaryKeys();
+        }
+
         return $this->map->listBySecondaryKey($packageName);
     }
 
@@ -167,7 +170,10 @@ class PathMappingCollection
      */
     public function getRepositoryPaths()
     {
-        $this->lazySortPrimaryKeys();
+        if ($this->primaryKeysSorted === true) {
+            $this->lazySortPrimaryKeys();
+        }
+
         return $this->map->getPrimaryKeys();
     }
 
@@ -179,7 +185,10 @@ class PathMappingCollection
      */
     public function toArray()
     {
-        $this->lazySortPrimaryKeys();
+        if ($this->primaryKeysSorted === true) {
+            $this->lazySortPrimaryKeys();
+        }
+
         return $this->map->toArray();
     }
 
@@ -199,9 +208,6 @@ class PathMappingCollection
      */
     private function lazySortPrimaryKeys()
     {
-        if( $this->primaryKeysSorted === true ){
-            return;
-        }
         $this->map->sortPrimaryKeys();
         $this->primaryKeysSorted = true;
     }

--- a/src/Repository/Mapping/PathMappingCollection.php
+++ b/src/Repository/Mapping/PathMappingCollection.php
@@ -34,6 +34,11 @@ class PathMappingCollection
     private $map;
 
     /**
+     * @var boolean
+     */
+    private $primaryKeysSorted = false;
+
+    /**
      * Creates the store.
      */
     public function __construct()
@@ -49,7 +54,7 @@ class PathMappingCollection
     public function add(PathMapping $mapping)
     {
         $this->map->set($mapping->getRepositoryPath(), $mapping->getContainingPackage()->getName(), $mapping);
-        $this->map->sortPrimaryKeys();
+        $this->primaryKeysSorted = false;
     }
 
     /**
@@ -61,7 +66,7 @@ class PathMappingCollection
     public function set($repositoryPath, PathMapping $mapping)
     {
         $this->map->set($repositoryPath, $mapping->getContainingPackage()->getName(), $mapping);
-        $this->map->sortPrimaryKeys();
+        $this->primaryKeysSorted = false;
     }
 
     /**
@@ -135,6 +140,7 @@ class PathMappingCollection
      */
     public function listByPackageName($packageName)
     {
+        $this->lazySortPrimaryKeys();
         return $this->map->listBySecondaryKey($packageName);
     }
 
@@ -161,6 +167,7 @@ class PathMappingCollection
      */
     public function getRepositoryPaths()
     {
+        $this->lazySortPrimaryKeys();
         return $this->map->getPrimaryKeys();
     }
 
@@ -172,6 +179,7 @@ class PathMappingCollection
      */
     public function toArray()
     {
+        $this->lazySortPrimaryKeys();
         return $this->map->toArray();
     }
 
@@ -184,5 +192,17 @@ class PathMappingCollection
     public function isEmpty()
     {
         return $this->map->isEmpty();
+    }
+
+    /**
+     * Sorts the map primary keys, if necessary.
+     */
+    private function lazySortPrimaryKeys()
+    {
+        if( $this->primaryKeysSorted === true ){
+            return;
+        }
+        $this->map->sortPrimaryKeys();
+        $this->primaryKeysSorted = true;
     }
 }

--- a/src/Repository/Mapping/PathMappingCollection.php
+++ b/src/Repository/Mapping/PathMappingCollection.php
@@ -140,7 +140,7 @@ class PathMappingCollection
      */
     public function listByPackageName($packageName)
     {
-        if ($this->primaryKeysSorted === true) {
+        if ($this->primaryKeysSorted) {
             $this->lazySortPrimaryKeys();
         }
 
@@ -170,7 +170,7 @@ class PathMappingCollection
      */
     public function getRepositoryPaths()
     {
-        if ($this->primaryKeysSorted === true) {
+        if ($this->primaryKeysSorted) {
             $this->lazySortPrimaryKeys();
         }
 
@@ -185,7 +185,7 @@ class PathMappingCollection
      */
     public function toArray()
     {
-        if ($this->primaryKeysSorted === true) {
+        if ($this->primaryKeysSorted) {
             $this->lazySortPrimaryKeys();
         }
 


### PR DESCRIPTION
Hi,

At the moment every call to PathMappingCollection::add()+set() sorts the primary keys of the PathMappingCollection map. 

On mapping a new path to an already large repository this ends up being the most time consuming operation after path canonicalization. This PR alters PathMappingCollection to mark the primary keys sorting status as dirty on each modification. On fetch operations whose ordering relies on the primary sorting, a function is called that checks if the primary keys sorting status is dirty and sorts them if so, marking the status as clean. 

Please check over the methods containing calls to lazySortPrimaryKeys() to make sure I've added it to all the methods that are affected by the primary keys being sorted.

The puli/manager test suite is currently giving me 3 failures on a fresh checkout (after composer install). This PR doesn't cause any additional failures. 

The failures present on fresh checkout give the following output:
```
There were 3 failures:

1) Puli\Manager\Tests\Config\ConfigJsonReaderTest::testReadConfigFileFailsIfDecodingNotPossible
Failed asserting that exception of type "Puli\Manager\Api\Config\NoSuchConfigKeyException" matches expected exception "\Puli\Manager\Api\InvalidConfigException". Message was: "The config key "plugins" does not exist." at
#0 /home/tolan/ttmp/pulitest/manager/src/Api/Config/Config.php(333): Puli\Manager\Api\Config\NoSuchConfigKeyException::forKey('plugins')
#1 /home/tolan/ttmp/pulitest/manager/src/Config/ConfigJsonReader.php(46): Puli\Manager\Api\Config\Config->set('plugins', Array)
#2 /home/tolan/ttmp/pulitest/manager/tests/Config/ConfigJsonReaderTest.php(101): Puli\Manager\Config\ConfigJsonReader->readConfigFile('/home/tolan/ttm...')
#3 [internal function]: Puli\Manager\Tests\Config\ConfigJsonReaderTest->testReadConfigFileFailsIfDecodingNotPossible()
#4 /home/tolan/ttmp/pulitest/manager/vendor/phpunit/phpunit/src/Framework/TestCase.php(866): ReflectionMethod->invokeArgs(Object(Puli\Manager\Tests\Config\ConfigJsonReaderTest), Array)
#5 /home/tolan/ttmp/pulitest/manager/vendor/phpunit/phpunit/src/Framework/TestCase.php(743): PHPUnit_Framework_TestCase->runTest()
#6 /home/tolan/ttmp/pulitest/manager/vendor/phpunit/phpunit/src/Framework/TestResult.php(610): PHPUnit_Framework_TestCase->runBare()
#7 /home/tolan/ttmp/pulitest/manager/vendor/phpunit/phpunit/src/Framework/TestCase.php(699): PHPUnit_Framework_TestResult->run(Object(Puli\Manager\Tests\Config\ConfigJsonReaderTest))
#8 /home/tolan/ttmp/pulitest/manager/vendor/phpunit/phpunit/src/Framework/TestSuite.php(731): PHPUnit_Framework_TestCase->run(Object(PHPUnit_Framework_TestResult))
#9 /home/tolan/ttmp/pulitest/manager/vendor/phpunit/phpunit/src/Framework/TestSuite.php(731): PHPUnit_Framework_TestSuite->run(Object(PHPUnit_Framework_TestResult))
#10 /home/tolan/ttmp/pulitest/manager/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(424): PHPUnit_Framework_TestSuite->run(Object(PHPUnit_Framework_TestResult))
#11 /usr/share/php/PHPUnit/TextUI/Command.php(186): PHPUnit_TextUI_TestRunner->doRun(Object(PHPUnit_Framework_TestSuite), Array)
#12 /usr/share/php/PHPUnit/TextUI/Command.php(138): PHPUnit_TextUI_Command->run(Array, true)
#13 /usr/bin/phpunit(42): PHPUnit_TextUI_Command::main()
#14 {main}.

/usr/share/php/PHPUnit/TextUI/Command.php:186
/usr/share/php/PHPUnit/TextUI/Command.php:138

2) Puli\Manager\Tests\Package\PackageJsonReaderTest::testReadPackageFileFailsIfDecodingNotPossible
Failed asserting that exception of type "\Puli\Manager\Api\InvalidConfigException" is thrown.

/usr/share/php/PHPUnit/TextUI/Command.php:186
/usr/share/php/PHPUnit/TextUI/Command.php:138

3) Puli\Manager\Tests\Package\PackageJsonReaderTest::testReadRootPackageFileFailsIfDecodingNotPossible
Failed asserting that exception of type "\Puli\Manager\Api\InvalidConfigException" is thrown.

/usr/share/php/PHPUnit/TextUI/Command.php:186
/usr/share/php/PHPUnit/TextUI/Command.php:138

```