### PR TITLE
Fix the detection of JSONC in tests

### DIFF
--- a/tests/Config/ConfigJsonReaderTest.php
+++ b/tests/Config/ConfigJsonReaderTest.php
@@ -92,10 +92,8 @@ class ConfigJsonReaderTest extends PHPUnit_Framework_TestCase
      */
     public function testReadConfigFileFailsIfDecodingNotPossible()
     {
-        if (false !== strpos(PHP_VERSION, 'ubuntu')) {
-            $this->markTestSkipped('This error is not reported on PHP versions compiled for Ubuntu.');
-
-            return;
+        if (defined('JSON_C_VERSION')) {
+            $this->markTestSkipped('This error is not reported when using JSONC.');
         }
 
         $this->reader->readConfigFile(__DIR__.'/Fixtures/win-1258.json');

--- a/tests/JsonWriterTestCase.php
+++ b/tests/JsonWriterTestCase.php
@@ -21,11 +21,11 @@ abstract class JsonWriterTestCase extends PHPUnit_Framework_TestCase
 {
     public static function assertJsonFileEquals($expected, $actual, $message = '', $canonicalize = false, $ignoreCase = false)
     {
-        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
-            if (false !== strpos(PHP_VERSION, 'ubuntu')) {
+        if (PHP_VERSION_ID >= 50400) {
+            if (PHP_VERSION_ID < 50428 || (PHP_VERSION_ID >= 50500 && PHP_VERSION_ID < 50512) || (defined('JSON_C_VERSION') && version_compare(phpversion('json'), '1.3.6', '<'))) {
                 self::assertEquals(
                     file_get_contents($expected),
-                    // Adjust to json_encode() compiled for Ubuntu:
+                    // Adjust to json_encode() compiled for early PHP versions or for JSONC before 1.3.6:
                     // Remove spaces between brackets of an empty object
                     preg_replace('/(?<=\{)\s+(?=\})/', '', file_get_contents($actual)),
                     $message,

--- a/tests/Package/PackageJsonReaderTest.php
+++ b/tests/Package/PackageJsonReaderTest.php
@@ -190,10 +190,8 @@ class PackageJsonReaderTest extends PHPUnit_Framework_TestCase
      */
     public function testReadPackageFileFailsIfDecodingNotPossible()
     {
-        if (false !== strpos(PHP_VERSION, 'ubuntu')) {
-            $this->markTestSkipped('This error is not reported on PHP versions compiled for Ubuntu.');
-
-            return;
+        if (defined('JSON_C_VERSION')) {
+            $this->markTestSkipped('This error is not reported when using JSONC.');
         }
 
         $this->reader->readPackageFile(__DIR__.'/Fixtures/json/win-1258.json');
@@ -205,10 +203,8 @@ class PackageJsonReaderTest extends PHPUnit_Framework_TestCase
      */
     public function testReadRootPackageFileFailsIfDecodingNotPossible()
     {
-        if (false !== strpos(PHP_VERSION, 'ubuntu')) {
-            $this->markTestSkipped('This error is not reported on PHP versions compiled for Ubuntu.');
-
-            return;
+        if (defined('JSON_C_VERSION')) {
+            $this->markTestSkipped('This error is not reported when using JSONC.');
         }
 
         $this->reader->readRootPackageFile(__DIR__.'/Fixtures/json/win-1258.json', $this->baseConfig);


### PR DESCRIPTION
- the possibility of detecting encoding issues depends on the usage of   JSONC, not on the fact that it is a version of PHP compiled by ubuntu
- the usage of spaces in empty objects when pretty-printing JSON is not specific to unbuntu builds. It affects PHP 5.4 before 5.4.28, 5.5 before 5.5.12 and the JSONC extension before 1.3.6 (this serie of version check is the one used in Composer when reimplementing pretty-printing for PHP 5.3 and testing it accross versions)

Closes https://github.com/puli/issues/issues/68