### PR TITLE
Added POST_ADD_ASSET_MAPPING and POST_REMOVE_ASSET_MAPPING events

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -11,6 +11,11 @@ enabled:
 disabled:
     - empty_return
 
+    # Puli is using a reserved keyword as a class
+    # (Puli\Repository\Api\Resource\Resource)
+    # https://github.com/puli/issues/issues/119
+    - phpdoc_types
+
     # Unusable at the moment
     # https://github.com/StyleCI/StyleCI/issues/471
     - psr0

--- a/src/Api/Event/AddAssetMappingEvent.php
+++ b/src/Api/Event/AddAssetMappingEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the puli/manager package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Puli\Manager\Api\Event;
+
+use Puli\Manager\Api\Asset\AssetMapping;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Dispatched when an asset mapping is added.
+ *
+ * @since  1.0
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class AddAssetMappingEvent extends Event
+{
+    /**
+     * @var AssetMapping
+     */
+    private $mapping;
+
+    /**
+     * Creates the event.
+     *
+     * @param AssetMapping $mapping The asset mapping.
+     */
+    public function __construct(AssetMapping $mapping)
+    {
+        $this->mapping = $mapping;
+    }
+
+    /**
+     * Returns the added asset mapping.
+     *
+     * @return AssetMapping The asset mapping.
+     */
+    public function getAssetMapping()
+    {
+        return $this->mapping;
+    }
+}

--- a/src/Api/Event/PuliEvents.php
+++ b/src/Api/Event/PuliEvents.php
@@ -31,7 +31,17 @@ interface PuliEvents
     const PRE_BUILD_REPOSITORY = 'puli.pre-build-repository';
 
     /**
-     * Dispatched before the resource repository is built.
+     * Dispatched after the resource repository is built.
      */
     const POST_BUILD_REPOSITORY = 'puli.post-build-repository';
+
+    /**
+     * Dispatched after adding asset mappings.
+     */
+    const POST_ADD_ASSET_MAPPING = 'puli.post-add-asset-mapping';
+
+    /**
+     * Dispatched after removing asset mappings.
+     */
+    const POST_REMOVE_ASSET_MAPPING = 'puli.post-remove-asset-mapping';
 }

--- a/src/Api/Event/RemoveAssetMappingEvent.php
+++ b/src/Api/Event/RemoveAssetMappingEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the puli/manager package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Puli\Manager\Api\Event;
+
+use Puli\Manager\Api\Asset\AssetMapping;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Dispatched when an asset mapping is removed.
+ *
+ * @since  1.0
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class RemoveAssetMappingEvent extends Event
+{
+    /**
+     * @var AssetMapping
+     */
+    private $mapping;
+
+    /**
+     * Creates the event.
+     *
+     * @param AssetMapping $mapping The asset mapping.
+     */
+    public function __construct(AssetMapping $mapping)
+    {
+        $this->mapping = $mapping;
+    }
+
+    /**
+     * Returns the removed asset mapping.
+     *
+     * @return AssetMapping The asset mapping.
+     */
+    public function getAssetMapping()
+    {
+        return $this->mapping;
+    }
+}


### PR DESCRIPTION
This PR adds events when `AssetMapping` instances are added removed. These events are needed for the [pulI/gulp-plugin](/puli/gulp-plugin).

Ping @tgalopin @mickaelandrieu for review