### PR TITLE
Fix System Utils Tests for HHVM; Clear env at setUp instead of tearDown

### DIFF
--- a/tests/Api/PuliTest.php
+++ b/tests/Api/PuliTest.php
@@ -64,8 +64,8 @@ class PuliTest extends PHPUnit_Framework_TestCase
         putenv('PULI_HOME='.$this->tempHome);
 
         // Make sure "HOME" (Unix)/"APPDATA" (Windows) is not set
-        putenv('HOME');
-        putenv('APPDATA');
+        putenv('HOME=');
+        putenv('APPDATA=');
 
         $this->puli = new Puli();
     }
@@ -76,7 +76,7 @@ class PuliTest extends PHPUnit_Framework_TestCase
         $filesystem->remove($this->tempDir);
 
         // Unset env variables
-        putenv('PULI_HOME');
+        putenv('PULI_HOME=');
     }
 
     public function testPuliProtectsHomeWithGlobalContext()
@@ -127,7 +127,7 @@ class PuliTest extends PHPUnit_Framework_TestCase
     public function testGetGlobalContextWithoutHome()
     {
         // Unset env variable
-        putenv('PULI_HOME');
+        putenv('PULI_HOME=');
 
         $this->puli->start();
         $context = $this->puli->getContext();
@@ -184,7 +184,7 @@ class PuliTest extends PHPUnit_Framework_TestCase
     public function testGetProjectContextWithoutHome()
     {
         // Unset env variable
-        putenv('PULI_HOME');
+        putenv('PULI_HOME=');
 
         $this->puli->setRootDirectory($this->tempRoot);
         $this->puli->start();

--- a/tests/Util/SystemTest.php
+++ b/tests/Util/SystemTest.php
@@ -30,6 +30,7 @@ class SystemTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        self::clearEnvironmentVariables();
         $this->tempHome = TestUtil::makeTempDir('puli-manager', __CLASS__);
     }
 
@@ -37,11 +38,18 @@ class SystemTest extends PHPUnit_Framework_TestCase
     {
         $filesystem = new Filesystem();
         $filesystem->remove($this->tempHome);
+    }
 
-        // Unset env variables
-        putenv('PULI_HOME');
-        putenv('HOME');
-        putenv('APPDATA');
+    public static function tearDownAfterClass()
+    {
+        self::clearEnvironmentVariables();
+    }
+
+    private static function clearEnvironmentVariables()
+    {
+        putenv('PULI_HOME=');
+        putenv('HOME=');
+        putenv('APPDATA=');
     }
 
     public function testParseHomeDirectory()


### PR DESCRIPTION
HHVM supports the `VAR_NAME=` notation to unset environment variables.
Clearing of env variables has been moved to setUp method.
Test cases are now completely isolated even if we run only one test case (eg. `testFailIfHomeNoDirectory`).