### PR TITLE
Fix JsonFileStore instanciation in JsonFileStoreGenerator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "puli/repository": "^1.0-beta9,<1.1",
         "puli/discovery": "^1.0-beta8",
         "puli/url-generator": "^1.0-beta3",
-        "webmozart/json": "^1.0",
+        "webmozart/json": "^1.1",
         "webmozart/path-util": "^2.2.3",
         "webmozart/expression": "^1.0-beta5",
         "webmozart/assert": "^1.0",

--- a/src/Factory/Generator/KeyValueStore/JsonFileStoreGenerator.php
+++ b/src/Factory/Generator/KeyValueStore/JsonFileStoreGenerator.php
@@ -29,7 +29,6 @@ class JsonFileStoreGenerator implements ServiceGenerator
 {
     private static $defaultOptions = array(
         'path' => 'data.json',
-        'cache' => true,
     );
 
     /**
@@ -46,10 +45,9 @@ class JsonFileStoreGenerator implements ServiceGenerator
 
         $targetMethod->getClass()->addImport(new Import('Webmozart\KeyValueStore\JsonFileStore'));
 
-        $targetMethod->addBody(sprintf('$%s = new JsonFileStore(%s, %s);',
+        $targetMethod->addBody(sprintf('$%s = new JsonFileStore(%s);',
             $varName,
-            '__DIR__.'.var_export('/'.$relPath, true),
-            $options['cache'] ? 'true' : 'false'
+            '__DIR__.'.var_export('/'.$relPath, true)
         ));
     }
 }

--- a/tests/Factory/FactoryManagerImplTest.php
+++ b/tests/Factory/FactoryManagerImplTest.php
@@ -157,7 +157,7 @@ class MyFactory
             throw new RuntimeException('Please install puli/repository to create ResourceRepository instances.');
         }
 
-        \$store = new JsonFileStore(__DIR__.'/.puli/path-mappings.json', true);
+        \$store = new JsonFileStore(__DIR__.'/.puli/path-mappings.json');
         \$repo = new PathMappingRepository(\$store, __DIR__);
 
         return \$repo;
@@ -176,7 +176,7 @@ class MyFactory
             throw new RuntimeException('Please install puli/discovery to create Discovery instances.');
         }
 
-        \$store = new JsonFileStore(__DIR__.'/.puli/bindings.json', true);
+        \$store = new JsonFileStore(__DIR__.'/.puli/bindings.json');
         \$discovery = new KeyValueStoreDiscovery(\$store, array(
             new ResourceBindingInitializer(\$repo),
         ));

--- a/tests/Factory/Generator/KeyValueStore/JsonFileStoreGeneratorTest.php
+++ b/tests/Factory/Generator/KeyValueStore/JsonFileStoreGeneratorTest.php
@@ -40,7 +40,7 @@ class JsonFileStoreGeneratorTest extends AbstractGeneratorTest
         ));
 
         $expected = <<<EOF
-\$store = new JsonFileStore(__DIR__.'/../data.json', true);
+\$store = new JsonFileStore(__DIR__.'/../data.json');
 EOF;
 
         $this->assertSame($expected, $this->method->getBody());
@@ -62,7 +62,7 @@ EOF;
         ));
 
         $expected = <<<EOF
-\$store = new JsonFileStore(__DIR__.'/data.json', true);
+\$store = new JsonFileStore(__DIR__.'/data.json');
 EOF;
 
         $this->assertSame($expected, $this->method->getBody());
@@ -76,21 +76,7 @@ EOF;
         ));
 
         $expected = <<<EOF
-\$store = new JsonFileStore(__DIR__.'/../d\'ir/dat\'a.da\'t', true);
-EOF;
-
-        $this->assertSame($expected, $this->method->getBody());
-    }
-
-    public function testGenerateServiceWithoutCaching()
-    {
-        $this->generator->generateNewInstance('store', $this->method, $this->registry, array(
-            'rootDir' => $this->rootDir,
-            'cache' => false,
-        ));
-
-        $expected = <<<EOF
-\$store = new JsonFileStore(__DIR__.'/../data.json', false);
+\$store = new JsonFileStore(__DIR__.'/../d\'ir/dat\'a.da\'t');
 EOF;
 
         $this->assertSame($expected, $this->method->getBody());

--- a/tests/JsonTestCase.php
+++ b/tests/JsonTestCase.php
@@ -49,7 +49,7 @@ abstract class JsonTestCase extends PHPUnit_Framework_TestCase
             // Remove all newlines + following spaces except for newline at EOF
             // Remove all single spaces after a colon that is preceded by an
             // object key
-            str_replace('/', '\/', preg_replace('/(?<=[^"]":) |\n\s*(?!$)/', '', $expected)),
+            preg_replace('/(?<=[^"]":) |\n\s*(?!$)/', '', $expected),
             $actual,
             $message,
             0,


### PR DESCRIPTION
The `GeneratedPuliFactory` currently uses a very old way to implement the `JsonKeyValueStore`, with a cache argument (see https://github.com/webmozart/key-value-store/commit/1e60c6750f67af693f9451f1f65073847efb882d). When we removed the second argument,  PHP simply ignored the boolean and it went unnoticed.

Later, when the `JsonKeyValueStore` got a second argument back (`$flag`, https://github.com/webmozart/key-value-store/commit/196c4c8ff4c643e6ba9f954ed482629620ac88d4#diff-d59c34cb33c1eb8de6bace8a46cfea1cR59), a problem started to appear and we got this issue : https://github.com/puli/issues/issues/142.

This PR aims to fix this. I removed the cache system completely as it seems a bit complicated to detect `doctrine/cache` in the generated file. What do you think?

> **Side note:** I think this isn't a BC-break as the `GeneratedPuliFactory` is a
> generated file, but please tell me if it is and I'll add a line in the Changelog.