### PR TITLE
Add Symfony 3 components to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         "webmozart/expression": "^1.0-beta5",
         "webmozart/assert": "^1.0",
         "webmozart/glob": "^3.1",
-        "symfony/event-dispatcher": "^2.3",
+        "symfony/event-dispatcher": "^2.3|^3.0",
         "webmozart/key-value-store": "^1.0-beta4",
-        "symfony/filesystem": "^2.3",
+        "symfony/filesystem": "^2.3|^3.0",
         "ramsey/uuid": "^2.8",
         "psr/log": "^1.0"
     },


### PR DESCRIPTION
After the release of Symfony 3 and the fact, that puli/manager is using the filesystem and event-dispatcher component, I added Symfony 3 support in composer.json.