### PR TITLE
Fixed JSON schema and schema testing

### DIFF
--- a/res/schema/package-schema-1.0.json
+++ b/res/schema/package-schema-1.0.json
@@ -20,11 +20,7 @@
             "additionalProperties": {
                 "type": "object",
                 "properties": {
-                    "query": {
-                        "type": "string",
-                        "required": true
-                    },
-                    "language": {
+                    "_class": {
                         "type": "string"
                     },
                     "type": {
@@ -34,6 +30,15 @@
                     "parameters": {
                         "type": "object",
                         "additionalProperties": true
+                    },
+                    "query": {
+                        "type": "string"
+                    },
+                    "language": {
+                        "type": "string"
+                    },
+                    "class": {
+                        "type": "string"
                     }
                 }
             }
@@ -105,9 +110,8 @@
                             "type": "string"
                         }
                     },
-                    "dev" : {
-                        "type": "bool",
-                        "required": false
+                    "env" : {
+                        "type": "string"
                     }
                 }
             }

--- a/src/Package/PackageJsonSerializer.php
+++ b/src/Package/PackageJsonSerializer.php
@@ -251,8 +251,9 @@ class PackageJsonSerializer implements PackageFileSerializer
 
                 // Don't include the default values of the binding type
                 if ($binding->hasParameterValues(false)) {
-                    $bindingData->parameters = $binding->getParameterValues(false);
-                    ksort($bindingData->parameters);
+                    $parameterData = $binding->getParameterValues(false);
+                    ksort($parameterData);
+                    $bindingData->parameters = (object) $parameterData;
                 }
 
                 $jsonData->bindings->{$bindingDescriptor->getUuid()->toString()} = $bindingData;

--- a/tests/Package/PackageJsonSerializerTest.php
+++ b/tests/Package/PackageJsonSerializerTest.php
@@ -205,7 +205,7 @@ JSON;
             ->willReturn(array('0.9', '1.0'));
         $this->serializer = new PackageJsonSerializer(
             $this->migrationManager,
-            __DIR__.'/Fixtures/schema',
+            __DIR__.'/../../res/schema',
             '1.0'
         );
     }
@@ -238,6 +238,13 @@ JSON;
 
     public function testSerializePackageFileDowngradesIfLowerVersion()
     {
+        // Use fixture schemas
+        $this->serializer = new PackageJsonSerializer(
+            $this->migrationManager,
+            __DIR__.'/Fixtures/schema',
+            '1.0'
+        );
+
         $packageFile = new PackageFile();
         $packageFile->setPackageName('my/application');
         $packageFile->setVersion('0.9');
@@ -633,6 +640,13 @@ JSON;
 
     public function testSerializeRootPackageFileDowngradesIfLowerVersion()
     {
+        // Use fixture schemas
+        $this->serializer = new PackageJsonSerializer(
+            $this->migrationManager,
+            __DIR__.'/Fixtures/schema',
+            '1.0'
+        );
+
         $packageFile = new RootPackageFile();
         $packageFile->setPackageName('my/application');
         $packageFile->setVersion('0.9');
@@ -1077,6 +1091,13 @@ JSON;
 
     public function testUnserializePackageFileUpgradesIfVersionTooLow()
     {
+        // Use fixture schemas
+        $this->serializer = new PackageJsonSerializer(
+            $this->migrationManager,
+            __DIR__.'/Fixtures/schema',
+            '1.0'
+        );
+
         $json = <<<JSON
 {
     "version": "0.9",
@@ -1118,6 +1139,13 @@ JSON;
 
     public function testUnserializeRootPackageFileUpgradesIfVersionTooLow()
     {
+        // Use fixture schemas
+        $this->serializer = new PackageJsonSerializer(
+            $this->migrationManager,
+            __DIR__.'/Fixtures/schema',
+            '1.0'
+        );
+
         $json = <<<JSON
 {
     "version": "0.9",


### PR DESCRIPTION
The JSON schema wasn't actually used for validation in the tests of the package file serializer. The serializer currently created some invalid JSON (according to the schema), but that went undetected.

This PR fixes both validation of the schema during tests as well as inconsistencies in the serializer and the schema.