### PR TITLE
Fixed generation of the JsonFileStore construction code

### DIFF
--- a/src/Factory/Generator/Repository/PathMappingRepositoryGenerator.php
+++ b/src/Factory/Generator/Repository/PathMappingRepositoryGenerator.php
@@ -46,6 +46,14 @@ class PathMappingRepositoryGenerator implements ServiceGenerator
         $kvsGenerator = $generatorRegistry->getServiceGenerator(GeneratorRegistry::KEY_VALUE_STORE, $options['store']['type']);
         $kvsOptions = $options['store'];
         $kvsOptions['rootDir'] = $options['rootDir'];
+
+        if ('json-file' === $kvsOptions['type']) {
+            $kvsOptions['serializeStrings'] = false;
+            $kvsOptions['serializeArrays'] = false;
+            $kvsOptions['escapeSlash'] = false;
+            $kvsOptions['prettyPrint'] = true;
+        }
+
         $kvsGenerator->generateNewInstance('store', $targetMethod, $generatorRegistry, $kvsOptions);
 
         $relPath = Path::makeRelative($options['rootDir'], $targetMethod->getClass()->getDirectory());

--- a/tests/Factory/FactoryManagerImplTest.php
+++ b/tests/Factory/FactoryManagerImplTest.php
@@ -182,13 +182,7 @@ class MyFactory
             throw new RuntimeException('Please install puli/discovery to create Discovery instances.');
         }
 
-        \$store = new JsonFileStore(
-            __DIR__.'/.puli/bindings.json',
-            JsonFileStore::NO_SERIALIZE_STRINGS
-                | JsonFileStore::NO_SERIALIZE_ARRAYS
-                | JsonFileStore::NO_ESCAPE_SLASH
-                | JsonFileStore::PRETTY_PRINT
-        );
+        \$store = new JsonFileStore(__DIR__.'/.puli/bindings.json');
         \$discovery = new KeyValueStoreDiscovery(\$store, array(
             new ResourceBindingInitializer(\$repo),
         ));

--- a/tests/Factory/Generator/KeyValueStore/JsonFileStoreGeneratorTest.php
+++ b/tests/Factory/Generator/KeyValueStore/JsonFileStoreGeneratorTest.php
@@ -40,13 +40,7 @@ class JsonFileStoreGeneratorTest extends AbstractGeneratorTest
         ));
 
         $expected = <<<EOF
-\$store = new JsonFileStore(
-    __DIR__.'/../data.json',
-    JsonFileStore::NO_SERIALIZE_STRINGS
-        | JsonFileStore::NO_SERIALIZE_ARRAYS
-        | JsonFileStore::NO_ESCAPE_SLASH
-        | JsonFileStore::PRETTY_PRINT
-);
+\$store = new JsonFileStore(__DIR__.'/../data.json');
 EOF;
 
         $this->assertSame($expected, $this->method->getBody());
@@ -68,13 +62,7 @@ EOF;
         ));
 
         $expected = <<<EOF
-\$store = new JsonFileStore(
-    __DIR__.'/data.json',
-    JsonFileStore::NO_SERIALIZE_STRINGS
-        | JsonFileStore::NO_SERIALIZE_ARRAYS
-        | JsonFileStore::NO_ESCAPE_SLASH
-        | JsonFileStore::PRETTY_PRINT
-);
+\$store = new JsonFileStore(__DIR__.'/data.json');
 EOF;
 
         $this->assertSame($expected, $this->method->getBody());
@@ -88,13 +76,7 @@ EOF;
         ));
 
         $expected = <<<EOF
-\$store = new JsonFileStore(
-    __DIR__.'/../d\'ir/dat\'a.da\'t',
-    JsonFileStore::NO_SERIALIZE_STRINGS
-        | JsonFileStore::NO_SERIALIZE_ARRAYS
-        | JsonFileStore::NO_ESCAPE_SLASH
-        | JsonFileStore::PRETTY_PRINT
-);
+\$store = new JsonFileStore(__DIR__.'/../d\'ir/dat\'a.da\'t');
 EOF;
 
         $this->assertSame($expected, $this->method->getBody());


### PR DESCRIPTION
Adjustments made for the JSON file of the PathMappingRepository also affected the KeyValueStoreDiscovery and broke it. This is fixed now.