### PR TITLE
Added DEFAULT_VERSION

### DIFF
--- a/src/Api/Module/ModuleFile.php
+++ b/src/Api/Module/ModuleFile.php
@@ -29,6 +29,8 @@ use Rhumsaa\Uuid\Uuid;
  */
 class ModuleFile
 {
+    const DEFAULT_VERSION = '1.0';
+
     /**
      * @var string
      */


### PR DESCRIPTION
We references to Package::DEFAULT_VERSION before. Has this been removed? Should I add the default version back like this?